### PR TITLE
OFAST-67 Fix Lesson Page Side Navigator Indexing Bug

### DIFF
--- a/src/pages/LessonPage.tsx
+++ b/src/pages/LessonPage.tsx
@@ -93,8 +93,8 @@ export default function LessonPage({ blocks }: LessonPageProps) {
       i + 1 < blockRefs.current.length &&
       sum + blockRefs.current[i].offsetHeight <= offsetY
     ) {
-      i++
       sum += blockRefs.current[i].offsetHeight
+      i++
     }
 
     return i


### PR DESCRIPTION
- On smaller windows, the lesson page side navigator was skipping bars
- This PR fixes a small bug in the code